### PR TITLE
Fixed a broken commented command related to changing the font sizes

### DIFF
--- a/beamer-templates/Turing-skeleton-example.tex
+++ b/beamer-templates/Turing-skeleton-example.tex
@@ -9,8 +9,15 @@
 \date{Date}
 \author{Author name(s)}
 
-% Uncomment line below to set custom size for main slide text (default is 32pt)
-%\setlength{\bodytext}{32pt}
+% Uncomment any of these lines below to set custom size for each of the font sizes.
+% The default value is shown in the comment.
+%\setlength{\titlefontsize}{6.875\basefontsize}
+%\setlength{\subtitlefontsize}{4.375\basefontsize}
+%\setlength{\frametitlesize}{2.625\basefontsize}
+%\setlength{\framesubtitlesize}{1.625\basefontsize}
+%\setlength{\bodytextsize}{2\basefontsize}
+%\setlength{\blocktitlesize}{\bodytextsize}
+%\setlength{\blockbodysize}{\bodytextsize}
 
 % Start document
 \begin{document}


### PR DESCRIPTION
The example of changing font size was missing a 'size' at the end i.e.

\setlength{\bodytext}

rather than:

\setlength{\bodytextsize}

Fixed this and added examples of changing several different font sizes for different bits of the document with their default values to make it easy to change these without having to go into the sty file.